### PR TITLE
Reduce size of resulting docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,16 @@ RUN set -x \
  && echo "deb http://extra.linuxmint.com/ rafaela main " >> /etc/apt/sources.list.d/mint.list \
  && : \
  && : xvnc / xfce installation \
- && apt-get update && apt-get upgrade -y && apt-get install -y supervisor vim xfce4 vnc4server wget unzip firefox \
+ && apt-get update \
+ && apt-get upgrade -y \
+ && apt-get install -y \
+	firefox \
+	supervisor \
+	unzip \
+	vim \
+	vnc4server \
+	wget \
+	xfce4 \
  && mkdir -p $NO_VNC_HOME/utils/websockify \
  && wget -qO- https://github.com/kanaka/noVNC/archive/master.tar.gz | tar xz --strip 1 -C $NO_VNC_HOME \
  && wget -qO- https://github.com/kanaka/websockify/archive/v0.7.0.tar.gz | tar xz --strip 1 -C $NO_VNC_HOME/utils/websockify \
@@ -41,15 +50,24 @@ RUN set -x \
  && update-alternatives --install "/usr/lib/firefox/browser/plugins/mozilla-javaplugin.so" "mozilla-javaplugin.so" "$JAVA_HOME/lib/amd64/libnpjp2.so" 1 \
  && : \
  && : Install chrome browser \
- && apt-get install -y chromium-browser chromium-browser-l10n chromium-codecs-ffmpeg \
+ && apt-get install -y \
+	chromium-browser \
+	chromium-browser-l10n \
+	chromium-codecs-ffmpeg \
  && ln -s /usr/bin/chromium-browser /usr/bin/google-chrome \
  && echo "alias chromium-browser='/usr/bin/chromium-browser --user-data-dir'" >> /root/.bashrc \
  && : \
  && : Setup specifics for android support - glx drivers etc. \
- && apt-get install libgl1-mesa-dev -y \
- && apt-get install libc6-i386 lib32stdc++6 lib32gcc1 lib32ncurses5 lib32z1 -y \
- && apt-get install nano -y \
- && apt-get install git -y \
+ && apt-get install -y \
+	git \
+	lib32gcc1 \
+	lib32ncurses5 \
+	lib32stdc++6 \
+	lib32z1 \
+	libc6-i386 \
+	libgl1-mesa-dev \
+	nano \
+ && apt-get clean \
  && : \
  && : Install Android SDK \
  && wget -qO- http://dl.google.com/android/android-sdk_r23.0.2-linux.tgz | tar xz -C /root/ --no-same-permissions \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,51 +19,50 @@ ENV VNC_PW vncpassword
 
 ENV SAKULI_DOWNLOAD_URL https://labs.consol.de/sakuli/install
 
-############### add linux-mint dependicies and update packages
-RUN apt-key adv --recv-key --keyserver keyserver.ubuntu.com "3EE67F3D0FF405B2"
-RUN echo "deb http://packages.linuxmint.com/ rafaela main upstream import" >> /etc/apt/sources.list.d/mint.list \
-    && echo "deb http://extra.linuxmint.com/ rafaela main " >> /etc/apt/sources.list.d/mint.list
-
-############### xvnc / xfce installation
-RUN apt-get update && apt-get upgrade -y && apt-get install -y supervisor vim xfce4 vnc4server wget unzip firefox
-### Install noVNC - HTML5 based VNC viewer
-RUN mkdir -p $NO_VNC_HOME/utils/websockify \
-    && wget -qO- https://github.com/kanaka/noVNC/archive/master.tar.gz | tar xz --strip 1 -C $NO_VNC_HOME \
-    &&  wget -qO- https://github.com/kanaka/websockify/archive/v0.7.0.tar.gz | tar xz --strip 1 -C $NO_VNC_HOME/utils/websockify \
-    && chmod +x -v /root/noVNC/utils/*.sh
-
-##### Add Oracle JAVA JRE8
-RUN mkdir -p $JAVA_HOME \
-    # download and extract
-    && wget -qO- $SAKULI_DOWNLOAD_URL/3rd-party/java/jre-$JAVA_VERSION-linux-x64.tar.gz | tar xz --strip 1 -C $JAVA_HOME \
-    # set alternatives
-    && update-alternatives --install "/usr/bin/java" "java" "$JAVA_HOME/bin/java" 1 \
-    && update-alternatives --install "/usr/bin/javaws" "javaws" "$JAVA_HOME/bin/javaws" 1 \
-    && update-alternatives --install "/usr/lib/firefox/browser/plugins/mozilla-javaplugin.so" "mozilla-javaplugin.so" "$JAVA_HOME/lib/amd64/libnpjp2.so" 1
-
-### Install chrome browser
-RUN apt-get install -y chromium-browser chromium-browser-l10n chromium-codecs-ffmpeg \
-    && ln -s /usr/bin/chromium-browser /usr/bin/google-chrome \
-    && echo "alias chromium-browser='/usr/bin/chromium-browser --user-data-dir'" >> /root/.bashrc
-
-# Setup specifics for android support - glx drivers etc.
-RUN apt-get install libgl1-mesa-dev -y
-RUN apt-get install libc6-i386 lib32stdc++6 lib32gcc1 lib32ncurses5 lib32z1 -y
-RUN apt-get install nano -y
-RUN apt-get install git -y
-
-# Install Android SDK
-RUN cd /root && wget -nv http://dl.google.com/android/android-sdk_r23.0.2-linux.tgz && tar xfo android-sdk_r23.0.2-linux.tgz --no-same-permissions && chmod -R a+rX android-sdk-linux
-RUN rm -rf /root/android-sdk_r23.0.2-linux.tgz
-
-# Install Android tools
-RUN echo y | /root/android-sdk-linux/tools/android update sdk --filter tools --no-ui --force -a
-RUN echo y | /root/android-sdk-linux/tools/android update sdk --filter platform-tools --no-ui --force -a
-RUN echo y | /root/android-sdk-linux/tools/android update sdk --filter platform --no-ui --force -a
-RUN echo y | /root/android-sdk-linux/tools/android update sdk --filter build-tools-21.0.1 --no-ui -a
-RUN echo y | /root/android-sdk-linux/tools/android update sdk --filter sys-img-x86-android-18 --no-ui -a
-RUN echo y | /root/android-sdk-linux/tools/android update sdk --filter sys-img-x86-android-19 --no-ui -a
-RUN echo y | /root/android-sdk-linux/tools/android update sdk --filter sys-img-x86-android-21 --no-ui -a
+RUN set -x \
+ && : \
+ && : add linux-mint dependicies and update packages \
+ && apt-key adv --recv-key --keyserver keyserver.ubuntu.com "3EE67F3D0FF405B2" \
+ && echo "deb http://packages.linuxmint.com/ rafaela main upstream import" >> /etc/apt/sources.list.d/mint.list \
+ && echo "deb http://extra.linuxmint.com/ rafaela main " >> /etc/apt/sources.list.d/mint.list \
+ && : \
+ && : xvnc / xfce installation \
+ && apt-get update && apt-get upgrade -y && apt-get install -y supervisor vim xfce4 vnc4server wget unzip firefox \
+ && mkdir -p $NO_VNC_HOME/utils/websockify \
+ && wget -qO- https://github.com/kanaka/noVNC/archive/master.tar.gz | tar xz --strip 1 -C $NO_VNC_HOME \
+ && wget -qO- https://github.com/kanaka/websockify/archive/v0.7.0.tar.gz | tar xz --strip 1 -C $NO_VNC_HOME/utils/websockify \
+ && chmod +x -v /root/noVNC/utils/*.sh \
+ && : \
+ && : Add Oracle JAVA JRE8 \
+ && mkdir -p $JAVA_HOME \
+ && wget -qO- $SAKULI_DOWNLOAD_URL/3rd-party/java/jre-$JAVA_VERSION-linux-x64.tar.gz | tar xz --strip 1 -C $JAVA_HOME \
+ && update-alternatives --install "/usr/bin/java" "java" "$JAVA_HOME/bin/java" 1 \
+ && update-alternatives --install "/usr/bin/javaws" "javaws" "$JAVA_HOME/bin/javaws" 1 \
+ && update-alternatives --install "/usr/lib/firefox/browser/plugins/mozilla-javaplugin.so" "mozilla-javaplugin.so" "$JAVA_HOME/lib/amd64/libnpjp2.so" 1 \
+ && : \
+ && : Install chrome browser \
+ && apt-get install -y chromium-browser chromium-browser-l10n chromium-codecs-ffmpeg \
+ && ln -s /usr/bin/chromium-browser /usr/bin/google-chrome \
+ && echo "alias chromium-browser='/usr/bin/chromium-browser --user-data-dir'" >> /root/.bashrc \
+ && : \
+ && : Setup specifics for android support - glx drivers etc. \
+ && apt-get install libgl1-mesa-dev -y \
+ && apt-get install libc6-i386 lib32stdc++6 lib32gcc1 lib32ncurses5 lib32z1 -y \
+ && apt-get install nano -y \
+ && apt-get install git -y \
+ && : \
+ && : Install Android SDK \
+ && wget -qO- http://dl.google.com/android/android-sdk_r23.0.2-linux.tgz | tar xz -C /root/ --no-same-permissions \
+ && chmod -R a+rX /root/android-sdk-linux \
+ && : \
+ && : Install Android tools \
+ && echo y | /root/android-sdk-linux/tools/android update sdk --filter tools --no-ui --force -a \
+ && echo y | /root/android-sdk-linux/tools/android update sdk --filter platform-tools --no-ui --force -a \
+ && echo y | /root/android-sdk-linux/tools/android update sdk --filter platform --no-ui --force -a \
+ && echo y | /root/android-sdk-linux/tools/android update sdk --filter build-tools-21.0.1 --no-ui -a \
+ && echo y | /root/android-sdk-linux/tools/android update sdk --filter sys-img-x86-android-18 --no-ui -a \
+ && echo y | /root/android-sdk-linux/tools/android update sdk --filter sys-img-x86-android-19 --no-ui -a \
+ && echo y | /root/android-sdk-linux/tools/android update sdk --filter sys-img-x86-android-21 --no-ui -a
 
 ENV ANDROID_HOME /root/android-sdk-linux
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ docker build -t android-emulator .
 ```
 docker run -dt -p 6901:6901 android-emulator
 ```
-* You can now browse to your host IP on port 6901 and run vnc_auto.html. (pwd below)
+* You can now browse to your host IP on port 6901 and run vnc_auto.html, eg. http://localhost:6901/vnc_auto.html (pwd below)
 * You'll now find the android SDK under the root folder, everything is now included in this build so you can run ./android avd to setup your emulators.
 * The default vnc password is "vncpassword".
 


### PR DESCRIPTION
I refactored the Dockerfile. The problem in your file is that some operations download files and following layers removed the files (after extracting). The problem is that the download creates an own layer which will be part of the whole chain and the download will always waste your space even if you don't see it. See `docker history your-image-name` for this.
This is kind-of-a-bug in docker. One of the feature requests speaking about this is https://github.com/docker/docker/issues/12169.
Anyway: I transformed your Dockerfile so that all commands are in one single RUN command. The result is a 6.778 GB image with much less layers which doesn't need any modification on your docker installation (AUFS)
